### PR TITLE
Add option to load config from file

### DIFF
--- a/printer/opts.go
+++ b/printer/opts.go
@@ -202,7 +202,7 @@ func (c *EnableUpgradeNotice) ApplyToContainerOption(cfg *ContainerOptions) {
 }
 
 // WithPrettyStyleFromEnv Load a custom style from environment variable
-func WithPrettyStyleFromEnv(envVariable string) (CustomPrettyStyle, error) {
+func WithPrettyStyleFromEnv(envVariable string) (*CustomPrettyStyle, error) {
 	path := os.Getenv(envVariable)
 	options, err := parseConfigFile(path)
 
@@ -210,19 +210,20 @@ func WithPrettyStyleFromEnv(envVariable string) (CustomPrettyStyle, error) {
 }
 
 // WithPrettyStyleFile Load a custom style from file
-func WithPrettyStyleFile(path string) (CustomPrettyStyle, error) {
+func WithPrettyStyleFile(path string) (*CustomPrettyStyle, error) {
 	options, err := parseConfigFile(path)
 
 	return options, err
 }
 
-func parseConfigFile(fileName string) (CustomPrettyStyle, error) {
-	var options CustomPrettyStyle
+func parseConfigFile(fileName string) (*CustomPrettyStyle, error) {
+	options := &CustomPrettyStyle{cfg: PrettyDefaultRenderConfig()}
 	styleConfig := style.DefaultConfig(PrettyLayoutGoTpl)
 	if fileName == "" {
 		return options, nil
 	}
 
+	fileName = filepath.Clean(fileName)
 	body, err := os.ReadFile(fileName)
 	if err != nil {
 		return options, err
@@ -231,16 +232,10 @@ func parseConfigFile(fileName string) (CustomPrettyStyle, error) {
 	extension := filepath.Ext(fileName)
 	switch extension {
 	case ".yml", ".yaml":
-		err = yaml.Unmarshal(body, &styleConfig)
+		err = yaml.Unmarshal(body, styleConfig)
 	case ".json":
-		err = json.Unmarshal(body, &styleConfig)
+		err = json.Unmarshal(body, styleConfig)
 	}
 
-	if err != nil {
-		return options, err
-	}
-	options = CustomPrettyStyle{
-		cfg: styleConfig,
-	}
-	return options, nil
+	return options, err
 }

--- a/printer/opts.go
+++ b/printer/opts.go
@@ -202,30 +202,30 @@ func (c *EnableUpgradeNotice) ApplyToContainerOption(cfg *ContainerOptions) {
 }
 
 // WithPrettyStyleFromEnv Load a custom style from environment variable
-func WithPrettyStyleFromEnv(envVariable string) []ContainerOption {
+func WithPrettyStyleFromEnv(envVariable string) (CustomPrettyStyle, error) {
 	path := os.Getenv(envVariable)
-	options := parseConfigFile(path)
+	options, err := parseConfigFile(path)
 
-	return options
+	return options, err
 }
 
 // WithPrettyStyleFile Load a custom style from file
-func WithPrettyStyleFile(path string) []ContainerOption {
-	options := parseConfigFile(path)
+func WithPrettyStyleFile(path string) (CustomPrettyStyle, error) {
+	options, err := parseConfigFile(path)
 
-	return options
+	return options, err
 }
 
-func parseConfigFile(fileName string) []ContainerOption {
-	var options []ContainerOption
+func parseConfigFile(fileName string) (CustomPrettyStyle, error) {
+	var options CustomPrettyStyle
 	styleConfig := style.DefaultConfig(PrettyLayoutGoTpl)
 	if fileName == "" {
-		return options
+		return options, nil
 	}
 
 	body, err := os.ReadFile(fileName)
 	if err != nil {
-		return options
+		return options, err
 	}
 
 	extension := filepath.Ext(fileName)
@@ -237,12 +237,10 @@ func parseConfigFile(fileName string) []ContainerOption {
 	}
 
 	if err != nil {
-		return options
+		return options, err
 	}
-
-	options = []ContainerOption{
-		WithPrettyFormatting(&styleConfig.Formatting),
-		WithPrettyLayout(&styleConfig.Layout),
+	options = CustomPrettyStyle{
+		cfg: styleConfig,
 	}
-	return options
+	return options, nil
 }

--- a/printer/opts.go
+++ b/printer/opts.go
@@ -218,7 +218,6 @@ func WithPrettyStyleFile(path string) (*CustomPrettyStyle, error) {
 
 func parseConfigFile(fileName string) (*CustomPrettyStyle, error) {
 	options := &CustomPrettyStyle{cfg: PrettyDefaultRenderConfig()}
-	styleConfig := style.DefaultConfig(PrettyLayoutGoTpl)
 	if fileName == "" {
 		return options, nil
 	}
@@ -232,9 +231,9 @@ func parseConfigFile(fileName string) (*CustomPrettyStyle, error) {
 	extension := filepath.Ext(fileName)
 	switch extension {
 	case ".yml", ".yaml":
-		err = yaml.Unmarshal(body, styleConfig)
+		err = yaml.Unmarshal(body, &options.cfg)
 	case ".json":
-		err = json.Unmarshal(body, styleConfig)
+		err = json.Unmarshal(body, &options.cfg)
 	}
 
 	return options, err

--- a/printer/opts.go
+++ b/printer/opts.go
@@ -201,7 +201,7 @@ func (c *EnableUpgradeNotice) ApplyToContainerOption(cfg *ContainerOptions) {
 	cfg.UpgradeNotice = upgrade.NewGitHubDetector(c.owner, c.repo, c.upgradeOpts...)
 }
 
-// Sets the Config using the path specified by an environment variable
+// WithPrettyStyleFromEnv Load a custom style from environment variable
 func WithPrettyStyleFromEnv(envVariable string) []ContainerOption {
 	path := os.Getenv(envVariable)
 	options := parseConfigFile(path)
@@ -209,14 +209,13 @@ func WithPrettyStyleFromEnv(envVariable string) []ContainerOption {
 	return options
 }
 
-// Configure version style using a stylesheet
+// WithPrettyStyleFile Load a custom style from file
 func WithPrettyStyleFile(path string) []ContainerOption {
 	options := parseConfigFile(path)
 
 	return options
 }
 
-// Returns a style config from a given file
 func parseConfigFile(fileName string) []ContainerOption {
 	var options []ContainerOption
 	styleConfig := style.DefaultConfig(PrettyLayoutGoTpl)

--- a/printer/pretty.go
+++ b/printer/pretty.go
@@ -18,9 +18,8 @@ type (
 	PrettyPostRenderFunc func(body string, isSmartTerminal bool) (string, error)
 )
 
-var (
-	// PrettyLayoutGoTpl prints all version data in a 'key  value' manner.
-	PrettyLayoutGoTpl = `{{ AdjustKeyWidth .ExtraFields }}
+// PrettyLayoutGoTpl prints all version data in a 'key  value' manner.
+var PrettyLayoutGoTpl = `{{ AdjustKeyWidth .ExtraFields }}
 {{ Header .Meta.CLIName }}
 
   {{ Key "Version"     }}    {{ .Version                     | Val }}
@@ -35,7 +34,6 @@ var (
   {{ $item.Key | Key   }}    {{ $item.Value | Val }}
   {{- end}}
 `
-)
 
 // Pretty prints human-readable version printing.
 type Pretty struct {
@@ -90,4 +88,9 @@ func (p *Pretty) execute(in *version.Info, isSmartTerminal bool) (string, error)
 	}
 
 	return p.customRenderFn(in, isSmartTerminal)
+}
+
+// PrettyDefaultRenderConfig returns the default render configuration when no customizations are provided.
+func PrettyDefaultRenderConfig() *style.Config {
+	return style.DefaultConfig(PrettyLayoutGoTpl)
 }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -187,6 +187,9 @@ func TestPrinterPrint(t *testing.T) {
 	assertGoldenFile(t, normalized)
 }
 
+// It uses the golden files, to update them run:
+//
+//	go test -v -run=TestPrinterStyleFileOptions ./printer/...  -update
 func TestPrinterStyleFileOptions(t *testing.T) {
 	tests := []struct {
 		testName string
@@ -211,8 +214,6 @@ func TestPrinterStyleFileOptions(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Setenv("config-file", tc.fileName+".yaml")
-			_, err = printer.WithPrettyStyleFromEnv("empty-variable")
-			require.NoError(t, err)
 
 			envStyle, err := printer.WithPrettyStyleFromEnv("config-file")
 			require.NoError(t, err)
@@ -224,8 +225,20 @@ func TestPrinterStyleFileOptions(t *testing.T) {
 	}
 }
 
-func validateStyle(customStyle printer.CustomPrettyStyle, t *testing.T) {
-	p := printer.New(&customStyle)
+// It uses the golden files, to update them run:
+//
+//	go test -v -run=TestPrinterStyleFromEnvOptionsUseDefaults ./printer/...  -update
+func TestPrinterStyleFromEnvOptionsUseDefaults(t *testing.T) {
+	emptyStyle, err := printer.WithPrettyStyleFromEnv("empty-variable")
+	require.NoError(t, err)
+
+	validateStyle(emptyStyle, t)
+}
+
+func validateStyle(customStyle *printer.CustomPrettyStyle, t *testing.T) {
+	t.Helper()
+
+	p := printer.New(customStyle)
 	var buff strings.Builder
 
 	err := p.Print(&buff)

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -232,7 +232,8 @@ func validateStyle(customStyle printer.CustomPrettyStyle, t *testing.T) {
 
 	require.NoError(t, err)
 
-	normalized := normalizeOutput(buff.String())
+	stripped := strings.TrimSpace(buff.String())
+	normalized := normalizeOutput(stripped)
 	assertGoldenFile(t, normalized)
 }
 

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
@@ -6,4 +6,3 @@
   Go version           1.19.4
   Compiler             gc
   Platform             fixed-platform
-  

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
@@ -1,4 +1,3 @@
-
 -> fixed-name
 
   Version              (devel)

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
@@ -1,0 +1,8 @@
+
+-> fixed-name
+
+  Version              (devel)
+  Dirty Build          no
+  Go version           1.19.5
+  Compiler             gc
+  Platform             fixed-platform

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
@@ -3,6 +3,6 @@
 
   Version              (devel)
   Dirty Build          no
-  Go version           1.19.5
+  Go version           1.19.4
   Compiler             gc
   Platform             fixed-platform

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_custom_layout.golden.txt
@@ -6,3 +6,4 @@
   Go version           1.19.4
   Compiler             gc
   Platform             fixed-platform
+  

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_default_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_default_layout.golden.txt
@@ -6,6 +6,6 @@
   Build Date           N/A
   Commit Date          N/A
   Dirty Build          no
-  Go version           1.19.5
+  Go version           1.19.4
   Compiler             gc
   Platform             fixed-platform

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_default_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_default_layout.golden.txt
@@ -1,0 +1,11 @@
+
+▓▓▓ fixed-name
+
+  Version              (devel)
+  Git Commit           N/A
+  Build Date           N/A
+  Commit Date          N/A
+  Dirty Build          no
+  Go version           1.19.5
+  Compiler             gc
+  Platform             fixed-platform

--- a/printer/testdata/TestPrinterStyleFileOptions/Print_default_layout.golden.txt
+++ b/printer/testdata/TestPrinterStyleFileOptions/Print_default_layout.golden.txt
@@ -1,4 +1,3 @@
-
 ▓▓▓ fixed-name
 
   Version              (devel)

--- a/printer/testdata/TestPrinterStyleFileOptions/customStyle.json
+++ b/printer/testdata/TestPrinterStyleFileOptions/customStyle.json
@@ -1,0 +1,28 @@
+{
+  "formatting": {
+    "header": {
+      "prefix": "-> ",
+      "color": "Magenta",
+      "background": "",
+      "options": null
+    },
+    "key": {
+      "color": "Yellow",
+      "background": "",
+      "options": [
+        "Bold"
+      ]
+    },
+    "val": {
+      "color": "Green",
+      "background": "",
+      "options": null
+    },
+    "date": {
+      "enableHumanizedSuffix": false
+    }
+  },
+    "layout": {
+      "goTemplate": "{{ AdjustKeyWidth .ExtraFields }}\n{{ Header .Meta.CLIName }}\n\n  {{ Key \"Version\"    }}    {{ .Version                     | Val }}\n  {{ Key \"Dirty Build\" }}    {{ .DirtyBuild | FmtBool        | Val }}\n  {{ Key \"Go version\"  }}    {{ .GoVersion  | trimPrefix \"go\"| Val }}\n  {{ Key \"Compiler\"    }}    {{ .Compiler                    | Val }}\n  {{ Key \"Platform\"    }}    {{ .Platform                    | Val }}\n  {{- range $item := (.ExtraFields | Extra) }}\n  {{ $item.Key | Key   }}    {{ $item.Value | Val }}\n  {{- end}}\n"
+  }
+}

--- a/printer/testdata/TestPrinterStyleFileOptions/customStyle.yaml
+++ b/printer/testdata/TestPrinterStyleFileOptions/customStyle.yaml
@@ -1,0 +1,31 @@
+formatting:
+  header:
+    prefix: '-> '
+    color: Magenta
+    background: ""
+    options: []
+  key:
+    color: Yellow
+    background: ""
+    options:
+      - Bold
+  val:
+    color: Green
+    background: ""
+    options: []
+  date:
+    enableHumanizedSuffix: true
+
+layout:
+  goTemplate: |
+    {{ AdjustKeyWidth .ExtraFields }}
+    {{ Header .Meta.CLIName }}
+
+      {{ Key "Version"     }}    {{ .Version                     | Val }}
+      {{ Key "Dirty Build" }}    {{ .DirtyBuild | FmtBool        | Val }}
+      {{ Key "Go version"  }}    {{ .GoVersion  | trimPrefix "go"| Val }}
+      {{ Key "Compiler"    }}    {{ .Compiler                    | Val }}
+      {{ Key "Platform"    }}    {{ .Platform                    | Val }}
+      {{- range $item := (.ExtraFields | Extra) }}
+      {{ $item.Key | Key   }}    {{ $item.Value | Val }}
+      {{- end}}

--- a/printer/testdata/TestPrinterStyleFileOptions/invalidStyle.json
+++ b/printer/testdata/TestPrinterStyleFileOptions/invalidStyle.json
@@ -1,0 +1,10 @@
+{
+  "format": {
+    "header": {
+      "prefix": "-> ",
+      "color": "Magenta",
+      "background": "",
+      "options": null
+    }
+  }
+}

--- a/printer/testdata/TestPrinterStyleFileOptions/invalidStyle.yaml
+++ b/printer/testdata/TestPrinterStyleFileOptions/invalidStyle.yaml
@@ -1,0 +1,6 @@
+format:
+  header:
+    prefix: '-> '
+    color: Magenta
+    background: ""
+    options: []

--- a/printer/testdata/TestPrinterStyleFromEnvOptionsUseDefaults.golden.txt
+++ b/printer/testdata/TestPrinterStyleFromEnvOptionsUseDefaults.golden.txt
@@ -1,0 +1,10 @@
+▓▓▓ fixed-name
+
+  Version              (devel)
+  Git Commit           N/A
+  Build Date           N/A
+  Commit Date          N/A
+  Dirty Build          no
+  Go version           1.19.4
+  Compiler             gc
+  Platform             fixed-platform


### PR DESCRIPTION
<!--   Thank you for your contribution -->

**Description**
This PR allows loading a custom style from a json or yaml file or an environment variable

### Examples
#### Using a loaded style with a Printer
```go
style, err := printer.WithPrettyStyleFile("version-style.yml")
p := printer.New(style)

// or 
// to load from an environment variable
style, err := printer.WithPrettyStyleFromEnv("version-style")
p := printer.New(style)
```

#### Using a loaded style with Cobra
```go
style := printer.WithPrettyStyleFile("version-style.yml")
cmd := &cobra.Command{
	Use:   "example",
	Short: "An example CLI built with github.com/spf13/cobra",
}
cmd.AddCommand(
	extension.NewVersionCobraCmd(
		extension.WithPrinterOptions(&style),
	),
)
```


**Related issue(s)**

-  #13 
